### PR TITLE
White on black option and escaping '<'

### DIFF
--- a/ansi2html.gemspec
+++ b/ansi2html.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'ansi2html'
-  s.version     = '5.3.2'
+  s.version     = '5.3.3'
   s.authors     = ["Aslak Hellesøy"]
   s.description = 'Convert ANSI escape sequences to styleable HTML markup'
   s.summary     = "#{s.name}-#{s.version}"

--- a/lib/ansi2html/main.rb
+++ b/lib/ansi2html/main.rb
@@ -64,7 +64,7 @@ module ANSI2HTML
 </head>
 <body><pre><code>}
       end
-      s = StringScanner.new(ansi)
+      s = StringScanner.new(ansi.gsub("<", "&lt;"))
       while(!s.eos?)
         if s.scan(/\e\[(3[0-7]|90|1)m/)
           out.print(%{<span class="#{COLOR[s[1]]}">})

--- a/lib/ansi2html/main.rb
+++ b/lib/ansi2html/main.rb
@@ -16,16 +16,20 @@ module ANSI2HTML
     }
     
     def self.execute
-      new(STDIN.read, STDOUT, ARGV.index('--envelope'))
+      new(STDIN.read, STDOUT, ARGV.index('--envelope'), ARGV.index('--black'))
     end
 
-    def initialize(ansi, out, envelope=false)
+    def initialize(ansi, out, envelope=false, black=false)
       if(envelope)
+        background, color = black ? %w(black white) : %w(white black)
         out.print %{<!doctype html>
 <html>
 <head>
   <meta charset="utf-8" />
   <style>
+    body {
+      background-color: #{background}; color: #{color};
+    }
     .bold {
       font-weight: bold;
     }


### PR DESCRIPTION
- added '--black' argument that reverts color and background color
- escaping '<' so it is displayed properly in html
