### PR TITLE
Handle escape codes that start with \e[0; 

### DIFF
--- a/lib/ansi2html/main.rb
+++ b/lib/ansi2html/main.rb
@@ -66,7 +66,7 @@ module ANSI2HTML
       end
       s = StringScanner.new(ansi.gsub("<", "&lt;"))
       while(!s.eos?)
-        if s.scan(/\e\[(3[0-7]|90|1)m/)
+        if s.scan(/\e\[(?:0;)?(3[0-7]|90|1)m/)
           out.print(%{<span class="#{COLOR[s[1]]}">})
         else
           if s.scan(/\e\[0m/)

--- a/lib/ansi2html/main.rb
+++ b/lib/ansi2html/main.rb
@@ -66,7 +66,7 @@ module ANSI2HTML
       end
       s = StringScanner.new(ansi.gsub("<", "&lt;"))
       while(!s.eos?)
-        if s.scan(/\e\[(?:0;)?(3[0-7]|90|1)m/)
+        if s.scan(/\e\[(?:\d;)?(3[0-7]|90|1)m/)
           out.print(%{<span class="#{COLOR[s[1]]}">})
         else
           if s.scan(/\e\[0m/)

--- a/spec/ansi2html/main_spec.rb
+++ b/spec/ansi2html/main_spec.rb
@@ -27,6 +27,12 @@ module ANSI2HTML
       out.string.should == '<span class="blue">Hello</span>'
     end
 
+    it "prints in blue when escape code is \e[0;34mHello\e[0m" do
+      out = StringIO.new
+      Main.new("\e[0;34mHello\e[0m", out)
+      out.string.should == '<span class="blue">Hello</span>'
+    end
+
     it "prints simply grey" do
       out = StringIO.new
       Main.new("\e[90mHello\e[0m", out)


### PR DESCRIPTION
The current gem doesn't work properly when the escape codes have 0; before the colour code. Puppet outputs this when run with coloured output. 

This is a quick and dirty fix to support that.
