### PR TITLE
Properly escape HTML

### DIFF
--- a/ansi2html.gemspec
+++ b/ansi2html.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.email       = 'aslak.hellesoy@gmail.com'
   s.homepage    = "http://github.com/aslakhellesoy/#{s.name}"
 
-  s.add_development_dependency 'rspec', '~> 2.3.0'
+  s.add_development_dependency 'rspec', '~> 2.13.0'
 
   s.files            = `git ls-files`.split("\n")
   s.test_files       = `git ls-files -- {spec,features}/*`.split("\n")

--- a/lib/ansi2html/main.rb
+++ b/lib/ansi2html/main.rb
@@ -1,4 +1,5 @@
 require 'strscan'
+require 'erb'
 
 module ANSI2HTML
   class Main
@@ -64,7 +65,7 @@ module ANSI2HTML
 </head>
 <body><pre><code>}
       end
-      s = StringScanner.new(ansi.gsub("<", "&lt;"))
+      s = StringScanner.new(ERB::Util.h(ansi))
       while(!s.eos?)
         if s.scan(/\e\[(3[0-7]|90|1)m/)
           out.print(%{<span class="#{COLOR[s[1]]}">})

--- a/spec/ansi2html/main_spec.rb
+++ b/spec/ansi2html/main_spec.rb
@@ -38,5 +38,11 @@ module ANSI2HTML
       Main.new("\e[37m\e[1mHello\e[0m\e[0m", out)
       out.string.should == '<span class="white"><span class="bold">Hello</span></span>'
     end
+
+    it "escapes HTML" do
+      out = StringIO.new
+      Main.new("hello \e[31mred <b class=\"large\">world</b>\e[0m", out)
+      out.string.should == 'hello <span class="red">red &lt;b class=&quot;large&quot;&gt;world&lt;/b&gt;</span>'
+    end
   end
 end


### PR DESCRIPTION
Ansi2html uses a rather simplistic way to escape HTML, namely by gsubbing all `<` with `&lt;`. However this does not properly escape all HTML. This patch uses ERB::Util.h to properly escape HTML.

I've also upgraded the RSpec dependency to ~> 2.13.0. Older versions of RSpec appear to contain bugs, which cause the tests to fail like this:

```
6) ANSI2HTML::Main white bold boys have more fun
     Failure/Error: Unable to find matching line from backtrace
          undefined method `run_all' for []:Array
               # /Users/hongli/.rvm/gems/ruby-1.9.3-p429/gems/rspec-core-2.3.1/lib/rspec/core/hooks.rb:116:in `run_hook_filtered'
```

Also, you should include Gemfile.lock in the repository. The lock file locks down specific versions so that other contributors who run 'bundle install' will get the exact same gem versions as you do, which prevents problems.
